### PR TITLE
ci: add Dependency-Track SBOM scan

### DIFF
--- a/.github/workflows/universal-dependency-track.yml
+++ b/.github/workflows/universal-dependency-track.yml
@@ -1,0 +1,180 @@
+name: Dependency Track SBOM Scan
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  schedule:
+    # Run daily at 9am UTC
+    - cron: '0 9 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  dependency-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js (if needed)
+        if: hashFiles('**/package.json') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Setup Python (if needed)
+        if: hashFiles('**/requirements.txt', '**/pyproject.toml', '**/setup.py') != ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Setup Go (if needed)
+        if: hashFiles('**/go.mod') != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Setup Java (if needed)
+        if: hashFiles('**/pom.xml', '**/build.gradle', '**/build.gradle.kts') != ''
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install dependencies (all languages, including monorepos)
+        run: |
+          echo "🔍 Detecting and installing dependencies..."
+
+          # Install pnpm if any pnpm-lock.yaml exists (needed for mixed monorepos)
+          if find . -name "pnpm-lock.yaml" -not -path "*/node_modules/*" | grep -q .; then
+            echo "📦 Installing pnpm globally (detected pnpm projects)"
+            npm install -g pnpm
+          fi
+
+          # Node.js: Check root first for workspace-level install
+          if [ -f "pnpm-lock.yaml" ]; then
+            echo "📦 Detected pnpm workspace at root"
+            pnpm install --no-frozen-lockfile --ignore-scripts 2>/dev/null || echo "Note: pnpm install failed, continuing..."
+          elif [ -f "yarn.lock" ]; then
+            echo "📦 Detected yarn workspace at root"
+            yarn install --ignore-scripts 2>/dev/null || echo "Note: yarn install failed, continuing..."
+          elif [ -f "package-lock.json" ]; then
+            echo "📦 Found npm project at root"
+            npm ci --ignore-scripts || npm install --ignore-scripts || echo "Note: npm install failed, continuing..."
+          elif [ -f "package.json" ]; then
+            echo "📦 Found Node.js project at root (no lock file)"
+            npm install --package-lock-only 2>/dev/null || echo "Note: npm install failed, continuing..."
+          fi
+
+          # Find all subdirectories and install based on their lock files (for mixed monorepos)
+          find . -type d -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "." | while read -r dir; do
+            if [ -f "$dir/pnpm-lock.yaml" ]; then
+              echo "📦 Found pnpm project in: $dir"
+              (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts 2>/dev/null || echo "Note: pnpm install failed in $dir")
+            elif [ -f "$dir/yarn.lock" ]; then
+              echo "📦 Found yarn project in: $dir"
+              (cd "$dir" && yarn install --ignore-scripts 2>/dev/null || echo "Note: yarn install failed in $dir")
+            elif [ -f "$dir/package-lock.json" ]; then
+              echo "📦 Found npm project in: $dir"
+              (cd "$dir" && (npm ci --ignore-scripts || npm install --ignore-scripts || echo "Note: npm install failed in $dir"))
+            elif [ -f "$dir/package.json" ]; then
+              echo "📦 Found Node.js project in: $dir (no lock file)"
+              (cd "$dir" && npm install --package-lock-only 2>/dev/null || echo "Note: npm install failed in $dir")
+            fi
+          done
+
+          # Python projects
+          find . -name "requirements.txt" -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/venv/*" | while read -r req; do
+            dir=$(dirname "$req")
+            echo "🐍 Found Python project in: $dir"
+            (cd "$dir" && pip install -r requirements.txt 2>/dev/null || echo "Note: pip install failed in $dir")
+          done
+
+          # Go projects
+          find . -name "go.mod" -not -path "*/node_modules/*" -not -path "*/.git/*" | while read -r gomod; do
+            dir=$(dirname "$gomod")
+            echo "🔷 Found Go project in: $dir"
+            (cd "$dir" && go mod download 2>/dev/null || echo "Note: go mod download failed in $dir")
+          done
+
+          # Java/Maven projects
+          find . -name "pom.xml" -not -path "*/node_modules/*" -not -path "*/.git/*" | while read -r pom; do
+            dir=$(dirname "$pom")
+            echo "☕ Found Maven project in: $dir"
+            (cd "$dir" && mvn dependency:resolve 2>/dev/null || echo "Note: mvn dependency:resolve failed in $dir")
+          done
+
+          # Java/Gradle projects
+          find . -name "build.gradle*" -not -path "*/node_modules/*" -not -path "*/.git/*" | while read -r gradle; do
+            dir=$(dirname "$gradle")
+            echo "☕ Found Gradle project in: $dir"
+            (cd "$dir" && (./gradlew dependencies 2>/dev/null || gradle dependencies 2>/dev/null || echo "Note: gradle dependencies failed in $dir"))
+          done
+
+          echo "✅ Dependency installation complete"
+        continue-on-error: true
+
+      - name: Generate SBOM with Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          format: cyclonedx
+          output: bom-raw.json
+          scanners: license
+          license-full: true
+
+      - name: Clean and validate SBOM
+        run: |
+          echo "🧹 Cleaning SBOM (removing lock files and false positives)..."
+          cat bom-raw.json | jq '
+            .components |= map(select(
+              .name != "package-lock.json" and
+              .name != "yarn.lock" and
+              .name != "pnpm-lock.yaml" and
+              .name != "go.mod" and
+              .name != "go.sum" and
+              .name != "uv.lock" and
+              .name != "poetry.lock" and
+              .name != "Pipfile.lock" and
+              .name != "Cargo.lock" and
+              .name != "composer.lock" and
+              (.name | test(".*lock\\.json$") | not)
+            ))
+          ' > bom.json
+
+          echo ""
+          echo "📊 SBOM Statistics:"
+          cat bom.json | jq '{
+              totalComponents: (.components | length),
+              componentsWithLicenses: ([.components[] | select(.licenses)] | length)
+          }'
+
+      - name: Upload BOM to Dependency-Track
+        # Uploading on pull_request would autocreate a DT project version
+        # named '<PR>/merge'. Only publish from the default branch.
+        if: github.event_name != 'pull_request'
+        uses: DependencyTrack/gh-upload-sbom@v3
+        with:
+          serverhostname: '44.194.0.211'
+          port: '8091'
+          protocol: 'http'
+          apikey: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+          projectname: ${{ github.event.repository.name }}
+          projectversion: ${{ github.event.repository.default_branch }}
+          bomfilename: 'bom.json'
+          autocreate: 'true'
+
+      - name: Archive SBOM artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sbom-cyclonedx
+          path: bom.json
+          retention-days: 90


### PR DESCRIPTION
Adds `.github/workflows/universal-dependency-track.yml`. Single new file, nothing else changes.

Generates a CycloneDX SBOM with Trivy and uploads it to Dependency-Track. This repo is one of 5 non-archived `mapup` repos with no DT coverage (47/52 are covered today).

## Secret

⚠️ **BLOCKER: `DEPENDENCYTRACK_API_KEY` is NOT visible to this repo.** The org secret is scoped to selected repositories and this one is not on the list. If merged now, `apikey` resolves to an empty string, the upload fails, and because the step is `continue-on-error: true` **the run still reports success** while nothing reaches Dependency-Track. An org admin must add this repo to the secret's repository list *before* merging.

## This is a corrected copy of the standard workflow

It is **not** a verbatim copy of the version deployed elsewhere — that version has three bugs we hit in production:

1. **`projectversion: ${{ github.ref_name }}` on a `pull_request` trigger** autocreates a DT project version named `<PR>/merge` for every PR. `navguru-mobile-app` accumulated **47 versions** this way. Here the upload is skipped on PRs (`if: github.event_name != 'pull_request'`).
2. **`projectversion: 'main'` hardcoded** misfiles SBOMs for `master`-default repos. Uses `${{ github.event.repository.default_branch }}` instead — this repo's default is `main`.
3. **The install step scans `node_modules`.** Only its first loop excludes it; the requirements.txt / go.mod / pom.xml / build.gradle loops do not. On a JS repo that means `./gradlew dependencies` runs for every Android module under `node_modules` — on `tollguru-mobile-app` that was 83 iterations, and every run was killed at GitHub's 6-hour job limit. `continue-on-error` does not save you: a job killed at the limit is *cancelled*, not *failed*. Fixed by excluding `node_modules` from all loops, plus `timeout-minutes: 20` so a hang fails loudly.

Also drops `2>/dev/null` from the npm branch (it was hiding a real lockfile error) and adds `--ignore-scripts` there to match the pnpm/yarn branches, so CI stops executing arbitrary dependency install hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)