### PR TITLE
fix: remove hardcoded Mapbox/TollGuru API keys from go/test/test.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 node_modules
+
+# Local credentials - never commit
+.env
+.env.*
+!.env.example

--- a/go/test/README.md
+++ b/go/test/README.md
@@ -23,3 +23,17 @@ The user has to enter the from and to in the CSV file and the program will give 
 ```
 
 Whole working code can be found in test.go file.
+
+### Running the tests
+
+The API keys are read from the environment, so export them before running:
+
+```sh
+export MAPBOX_API_KEY="your-mapbox-token"
+export TOLLGURU_API_KEY="your-tollguru-key"
+
+cd go/test
+go run test.go
+```
+
+Never hardcode the keys in `test.go` — the repository is public and committed secrets stay in git history even after they are deleted.

--- a/go/test/test.go
+++ b/go/test/test.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	MAPBOX_API_KEY   string = "pk.eyJ1IjoiYWJoaW5hdm1hcHVwIiwiYSI6ImNsdGd6cnhjZjAyMTAybWs4cG5vNXA4bGgifQ.XPDJnVJjo2WxRkVm-vzygA"
-	TOLLGURU_API_KEY string = "Dd6AAjtNnBrb9hrBLB9jqpF79JL8DfnA"
+	MAPBOX_API_KEY   string = os.Getenv("MAPBOX_API_KEY")
+	TOLLGURU_API_KEY string = os.Getenv("TOLLGURU_API_KEY")
 )
 
 const (
@@ -65,6 +65,10 @@ func readCsvFile(filePath string) [][]string {
 }
 
 func main() {
+	if MAPBOX_API_KEY == "" || TOLLGURU_API_KEY == "" {
+		log.Fatalln("Set the MAPBOX_API_KEY and TOLLGURU_API_KEY environment variables before running")
+	}
+
 	records := readCsvFile(filePath)
 
 	for i := 1; i < len(records); i++ {


### PR DESCRIPTION
## What

Gitleaks flagged 2 secrets in `go/test/test.go` (rule `generic-api-key`), introduced in commit `9820dc7` (2024-03-07):

| Variable | Location |
|---|---|
| `MAPBOX_API_KEY` | `go/test/test.go:17` |
| `TOLLGURU_API_KEY` | `go/test/test.go:18` |

Commit `6dcc649` (the day before) correctly used placeholder strings — `9820dc7` replaced them with live credentials, so this was a regression.

## Changes

- Read both keys via `os.Getenv`, matching the convention already used in `go/index.go:15-16`.
- Fail fast with a clear message when the env vars are unset. Previously a missing key surfaced as an opaque type-assertion panic deep in response parsing.
- Ignore `.env` files — `python/` and `javascript/` both use dotenv, but `.env` was never in `.gitignore`.
- Document the required env vars in `go/test/README.md`.

## Testing

- All **9/9** test cases in `test.csv` produce toll rates.
- Output diffed byte-for-byte against a build of the pre-change version: **identical**. The `<nil>` on the Whitby→Orono row is pre-existing (no tag toll on that route).
- `go vet` and `go build` clean.
- `gitleaks detect --no-git` on the working tree: **no leaks found**.

## Follow-up required

This removes the keys from the current code, but **`9820dc7` still contains them in git history**, so the gitleaks CI job will keep reporting 2 findings until history is purged separately.

Both keys were confirmed **still live** at the time of writing and must be revoked, not just superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)